### PR TITLE
Fix for incorrect startup display

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,26 @@
+let Http = require("http")
+let logger = require("backend/logger")
+let app = require("backend/app")
+
+let server = Http.createServer(app)
+server.on("error", onError)
+server.on("listening", () => logger.info("Listening on port " + process.env.HTTP_PORT || 3000))
+server.listen(process.env.HTTP_PORT || 3000);
+
+function onError(error) {
+  if (error.syscall !== "listen") {
+    throw error
+  }
+  switch (error.code) {
+    case "EACCES":
+      logger.error(process.env.HTTP_PORT + " requires elevated privileges")
+      process.exit(1)
+      break
+    case "EADDRINUSE":
+      logger.error(process.env.HTTP_PORT + " is already in use")
+      process.exit(1)
+      break
+    default:
+      throw error
+  }
+}

--- a/frontend/state.js
+++ b/frontend/state.js
@@ -12,8 +12,8 @@ let monkey = Baobab.monkey
 window._state = new Baobab(
   {
     url: {
-      route: undefined,
-      path: undefined,
+      route: '/public',
+      path: 'http://localhost:3000/public/',
       params: {},
       query: {},
     },


### PR DESCRIPTION
In reference to the many issues being brought up by people who were not able to get the site to start up correctly, and were brought to a folder simply listing the files, I found that this solution worked for me. By modifying "**backend/server.js**" and "**frontend/state.js**", the site now loads as intended.

In "**backend/server.js**"
```
server.on("listening", () => logger.info("Listening on port " + process.env.HTTP_PORT))
server.listen(process.env.HTTP_PORT);
```
should be (_port number should be whatever port user is intending to use_)
```
server.on("listening", () => logger.info("Listening on port " + process.env.HTTP_PORT || 3000))
server.listen(process.env.HTTP_PORT || 3000);
```



and in "**frontend/state.js**"
```
window._state = new Baobab(
  {
    url: {
      route: undefined,
      path: undefined,
      params: {},
      query: {},
    },
```

should instead be
```
window._state = new Baobab(
  {
    url: {
      route: '/public',
      path: 'http://localhost:3000/public/',
      params: {},
      query: {},
    },
```
